### PR TITLE
Upgraded to AndroidX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-26.0.2
-    - android-26
+    - build-tools-28.0.2
+    - android-28
     - extra-android-m2repository
     - extra-android-support
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha05'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jul 28 18:39:30 AEST 2018
+#Wed Aug 08 16:20:21 CDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip

--- a/pinentryedittext/build.gradle
+++ b/pinentryedittext/build.gradle
@@ -12,7 +12,7 @@ ext {
     siteUrl = 'https://github.com/alphamu/PinEntryEditText'
     gitUrl = 'https://github.com/alphamu/PinEntryEditText.git'
 
-    libraryVersion = '1.3.3'
+    libraryVersion = '2.0.0'
 
     developerId = 'alphamu'
     developerName = 'Ali Muzaffar'
@@ -31,7 +31,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 28
         versionCode 1
-        versionName '1.3.3'
+        versionName '2.0.0'
     }
     buildTypes {
         release {
@@ -47,7 +47,8 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.12'
-    implementation 'com.android.support:appcompat-v7:28.0.0-beta01'
+
+    implementation 'androidx.appcompat:appcompat:1.0.0-rc01'
 }
 
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'

--- a/pinentryedittext/build.gradle
+++ b/pinentryedittext/build.gradle
@@ -25,7 +25,7 @@ ext {
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "27.0.3"
+    buildToolsVersion "28.0.2"
 
     defaultConfig {
         minSdkVersion 14

--- a/pinentryedittext/src/main/java/com/alimuzaffar/lib/pin/PinEntryEditText.java
+++ b/pinentryedittext/src/main/java/com/alimuzaffar/lib/pin/PinEntryEditText.java
@@ -18,7 +18,6 @@ package com.alimuzaffar.lib.pin;
 import android.animation.Animator;
 import android.animation.AnimatorSet;
 import android.animation.ValueAnimator;
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
@@ -28,10 +27,6 @@ import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
-import android.support.v4.content.ContextCompat;
-import android.support.v4.text.TextUtilsCompat;
-import android.support.v4.view.ViewCompat;
 import android.text.InputFilter;
 import android.text.InputType;
 import android.text.TextUtils;
@@ -43,11 +38,15 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.animation.OvershootInterpolator;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.EditText;
 
 import java.util.Locale;
 
-public class PinEntryEditText extends EditText {
+import androidx.appcompat.widget.AppCompatEditText;
+import androidx.core.content.ContextCompat;
+import androidx.core.text.TextUtilsCompat;
+import androidx.core.view.ViewCompat;
+
+public class PinEntryEditText extends AppCompatEditText {
     private static final String XML_NAMESPACE_ANDROID = "http://schemas.android.com/apk/res/android";
 
     protected String mMask = null;
@@ -104,12 +103,6 @@ public class PinEntryEditText extends EditText {
 
     public PinEntryEditText(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        init(context, attrs);
-    }
-
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    public PinEntryEditText(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
-        super(context, attrs, defStyleAttr, defStyleRes);
         init(context, attrs);
     }
 

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "27.0.3"
+    buildToolsVersion "28.0.2"
 
     defaultConfig {
         applicationId "com.alimuzaffar.sample.pin"

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 28
         versionCode 1
-        versionName "1.3.3"
+        versionName "2.0.0"
     }
     buildTypes {
         release {
@@ -25,6 +25,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar, *.aar'], dir: 'libs')
     testImplementation 'junit:junit:4.12'
-    implementation 'com.android.support:appcompat-v7:28.0.0-beta01'
+
+    implementation 'androidx.appcompat:appcompat:1.0.0-rc01'
     implementation project(':pinentryedittext')
 }

--- a/sample-app/src/main/java/com/alimuzaffar/sample/pin/AnimatedEditTextWidgetsActivity.java
+++ b/sample-app/src/main/java/com/alimuzaffar/sample/pin/AnimatedEditTextWidgetsActivity.java
@@ -1,10 +1,11 @@
 package com.alimuzaffar.sample.pin;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.widget.Toast;
 
 import com.alimuzaffar.lib.pin.PinEntryEditText;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 public class AnimatedEditTextWidgetsActivity extends AppCompatActivity {
 
@@ -13,7 +14,7 @@ public class AnimatedEditTextWidgetsActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_edit_text);
 
-        final PinEntryEditText pinEntry = (PinEntryEditText) findViewById(R.id.txt_pin_entry);
+        final PinEntryEditText pinEntry = findViewById(R.id.txt_pin_entry);
         if (pinEntry != null) {
             pinEntry.setOnPinEnteredListener(new PinEntryEditText.OnPinEnteredListener() {
                 @Override
@@ -34,7 +35,7 @@ public class AnimatedEditTextWidgetsActivity extends AppCompatActivity {
             });
         }
 
-        final PinEntryEditText pinEntry2 = (PinEntryEditText) findViewById(R.id.txt_pin_entry2);
+        final PinEntryEditText pinEntry2 = findViewById(R.id.txt_pin_entry2);
         if (pinEntry2 != null) {
             pinEntry2.setAnimateText(true);
             pinEntry2.setOnPinEnteredListener(new PinEntryEditText.OnPinEnteredListener() {


### PR DESCRIPTION
Fixes #40 
- Now depends on AndroidX AppCompat

- Extend AppCompatEditText instead of EditText

- Bumped version to 2.0.0 because it's a breaking change