### PR TITLE
Resizing view after setMaxLength called

### DIFF
--- a/pinentryedittext/src/main/java/com/alimuzaffar/lib/pin/PinEntryEditText.java
+++ b/pinentryedittext/src/main/java/com/alimuzaffar/lib/pin/PinEntryEditText.java
@@ -61,6 +61,8 @@ public class PinEntryEditText extends AppCompatEditText {
     protected int mMaxLength = 4;
     protected RectF[] mLineCoords;
     protected float[] mCharBottom;
+    protected int mWidth = 0;
+    protected int mHeight = 0;
     protected Paint mCharPaint;
     protected Paint mLastCharPaint;
     protected Paint mSingleCharPaint;
@@ -112,8 +114,10 @@ public class PinEntryEditText extends AppCompatEditText {
         mNumChars = maxLength;
 
         setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
-
         setText(null);
+       
+        onSizeChanged(mWidth, mHeight , mWidth, mHeight);
+
         invalidate();
     }
 
@@ -251,6 +255,8 @@ public class PinEntryEditText extends AppCompatEditText {
 
     @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+        mWidth = w;
+        mHeight = h;
         super.onSizeChanged(w, h, oldw, oldh);
         mOriginalTextColors = getTextColors();
         if (mOriginalTextColors != null) {


### PR DESCRIPTION
Fixing two issues with setMaxLength if you call it after the view has been initialized. (e.g. after a button press)

When you call setMaxLength it now calls onSizeChanged to update all the values.  In onSizeChanged the width and height is recorded for future use if setMaxLength is called.

1 - If number is larger than the initialized number, it would crash with an out of bounds exception.  E.g 4 -> 5

2 - If the number is smaller than initialized number, the view would retain the width of the initial number, and the smaller entry dashes would be displayed starting from the left and then stopping mid way through the screen.