### PR TITLE
Add support to get max length integer value via integer id

### DIFF
--- a/pinentryedittext/src/main/java/com/alimuzaffar/lib/pin/PinEntryEditText.java
+++ b/pinentryedittext/src/main/java/com/alimuzaffar/lib/pin/PinEntryEditText.java
@@ -21,7 +21,6 @@ import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
 import android.graphics.*;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.text.*;
 import android.util.AttributeSet;
 import android.util.TypedValue;
@@ -34,10 +33,9 @@ import androidx.appcompat.widget.AppCompatEditText;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
 
-import java.lang.reflect.Field;
-
 public class PinEntryEditText extends AppCompatEditText {
 
+    private static final String XML_NAMESPACE_ANDROID = "http://schemas.android.com/apk/res/android";
     private static final int DEFAULT_MAX_LENGTH = 4;
     public static final String DEFAULT_MASK = "\u25CF";
 
@@ -167,7 +165,7 @@ public class PinEntryEditText extends AppCompatEditText {
 
         setBackgroundResource(0);
 
-        mMaxLength = getMaxLength();
+        mMaxLength = getAndroidAttributeIntValue(attrs, "maxLength", DEFAULT_MAX_LENGTH);
         mNumChars = mMaxLength;
 
         //Disable copy paste
@@ -223,24 +221,13 @@ public class PinEntryEditText extends AppCompatEditText {
         mAnimate = mAnimatedType > -1;
     }
 
-    private int getMaxLength() {
-        for (InputFilter filter : getFilters()) {
-            if (filter instanceof InputFilter.LengthFilter) {
-                InputFilter.LengthFilter lengthFilter = ((InputFilter.LengthFilter) filter);
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                    return lengthFilter.getMax();
-                } else {
-                    try {
-                        Field max = InputFilter.LengthFilter.class.getDeclaredField("mMax");
-                        max.setAccessible(true);
-                        return (int) max.get(lengthFilter);
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-            }
+    private int getAndroidAttributeIntValue(AttributeSet attrs, String attributeName, int defaultValue) {
+        int resId = attrs.getAttributeResourceValue(XML_NAMESPACE_ANDROID, attributeName, -1);
+        if (resId > 0) {
+            return getResources().getInteger(resId);
+        } else {
+            return attrs.getAttributeIntValue(XML_NAMESPACE_ANDROID, attributeName, defaultValue);
         }
-        return DEFAULT_MAX_LENGTH;
     }
 
     @Override

--- a/pinentryedittext/src/main/java/com/alimuzaffar/lib/pin/PinEntryEditText.java
+++ b/pinentryedittext/src/main/java/com/alimuzaffar/lib/pin/PinEntryEditText.java
@@ -15,28 +15,17 @@
  */
 package com.alimuzaffar.lib.pin;
 
-import android.animation.Animator;
-import android.animation.AnimatorSet;
-import android.animation.ValueAnimator;
+import android.animation.*;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
-import android.graphics.Canvas;
-import android.graphics.Color;
-import android.graphics.Paint;
-import android.graphics.Rect;
-import android.graphics.RectF;
-import android.graphics.Typeface;
+import android.graphics.*;
 import android.graphics.drawable.Drawable;
-import android.text.InputFilter;
-import android.text.InputType;
-import android.text.TextUtils;
+import android.os.Build;
+import android.text.*;
 import android.util.AttributeSet;
 import android.util.TypedValue;
-import android.view.ActionMode;
-import android.view.Menu;
-import android.view.MenuItem;
-import android.view.View;
+import android.view.*;
 import android.view.animation.OvershootInterpolator;
 import android.view.inputmethod.InputMethodManager;
 
@@ -45,9 +34,11 @@ import androidx.appcompat.widget.AppCompatEditText;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
 
-public class PinEntryEditText extends AppCompatEditText {
-    private static final String XML_NAMESPACE_ANDROID = "http://schemas.android.com/apk/res/android";
+import java.lang.reflect.Field;
 
+public class PinEntryEditText extends AppCompatEditText {
+
+    private static final int DEFAULT_MAX_LENGTH = 4;
     public static final String DEFAULT_MASK = "\u25CF";
 
     protected String mMask = null;
@@ -56,9 +47,9 @@ public class PinEntryEditText extends AppCompatEditText {
     protected int mAnimatedType = 0;
     protected float mSpace = 24; //24 dp by default, space between the lines
     protected float mCharSize;
-    protected float mNumChars = 4;
+    protected float mNumChars = DEFAULT_MAX_LENGTH;
     protected float mTextBottomPadding = 8; //8dp by default, height of the text from our lines
-    protected int mMaxLength = 4;
+    protected int mMaxLength = DEFAULT_MAX_LENGTH;
     protected RectF[] mLineCoords;
     protected float[] mCharBottom;
     protected Paint mCharPaint;
@@ -176,7 +167,7 @@ public class PinEntryEditText extends AppCompatEditText {
 
         setBackgroundResource(0);
 
-        mMaxLength = attrs.getAttributeIntValue(XML_NAMESPACE_ANDROID, "maxLength", 4);
+        mMaxLength = getMaxLength();
         mNumChars = mMaxLength;
 
         //Disable copy paste
@@ -230,6 +221,26 @@ public class PinEntryEditText extends AppCompatEditText {
         getPaint().getTextBounds("|", 0, 1, mTextHeight);
 
         mAnimate = mAnimatedType > -1;
+    }
+
+    private int getMaxLength() {
+        for (InputFilter filter : getFilters()) {
+            if (filter instanceof InputFilter.LengthFilter) {
+                InputFilter.LengthFilter lengthFilter = ((InputFilter.LengthFilter) filter);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    return lengthFilter.getMax();
+                } else {
+                    try {
+                        Field max = InputFilter.LengthFilter.class.getDeclaredField("mMax");
+                        max.setAccessible(true);
+                        return (int) max.get(lengthFilter);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+        return DEFAULT_MAX_LENGTH;
     }
 
     @Override

--- a/sample-app/src/main/res/layout/activity_edit_text.xml
+++ b/sample-app/src/main/res/layout/activity_edit_text.xml
@@ -44,7 +44,7 @@
             android:cursorVisible="false"
             android:digits="1234567890"
             android:inputType="number"
-            android:maxLength="6"
+            android:maxLength="@integer/pin_length"
             android:textIsSelectable="false"
             android:textSize="24dp"
             app:pinAnimationType="fromBottom"

--- a/sample-app/src/main/res/values/integers.xml
+++ b/sample-app/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="pin_length">6</integer>
+</resources>


### PR DESCRIPTION
## What happened 🤔
- `attrs.getAttributeIntValue(XML_NAMESPACE_ANDROID, "maxLength", 4)` doesn't support to get max length int value from an integer id.


## Insight 👀
- The default way to support getting int value from int id value is using `TypeArray.getInt(com.android.internal.R.styleable.TextView_maxLength, -1)`, but custom `PinEntryEditText` class can't access to `com.android.internal.R.styleable.TextView_maxLength`.
- There is another approach to get the current value of max length from `android:maxLength` property. `android:maxLength` was initialized via `TextView` into `InputFilter.LengthFilter`, so we could get this value out from current filter list. Note that, `InputFilter.LengthFilter.getMax()` is only supported from API 21, so we need to use reflection to get `mMax` value out in lower APIs. `mMax` field was introduced from the first version of `InputFilter` https://android.googlesource.com/platform/frameworks/base/+/54b6cfa9a9e5b861a9930af873580d6dc20f773c/core/java/android/text/InputFilter.java

- **After rechecked, it seems getting value out from `mMax` by reflection on API 19 is not a pretty way, back to getting value from resid or raw int value https://stackoverflow.com/a/60593495.**

## PoW (a.k.a Proof Of Work)💪
- API 21
<img src="https://user-images.githubusercontent.com/16315358/79831459-a782eb80-83d1-11ea-94b1-de49adb14498.png" width=200 />


- API 19
<img src="https://user-images.githubusercontent.com/16315358/79831260-43f8be00-83d1-11ea-9c02-6710a0c4c3d9.png" width=200 />

