### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ sudo: false
 before_install:
 - export ANDROID_HOME=/usr/local/android-sdk
 - echo "sdk.dir=$ANDROID_HOME" > local.properties
-script: 'travis_retry ./gradlew assembleRelease'
+script: ' ./gradlew assembleRelease'
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION

Does travis_retry really solve the build issues? According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
